### PR TITLE
Changed list design in helpfoss.md

### DIFF
--- a/helpfoss.md
+++ b/helpfoss.md
@@ -2,18 +2,35 @@
 
 Many people like Free Software but think that they cannot contribute if they can't programm. This (*non exhaustive*) list shows how supporters can help different projects. 
 
-List
+###Free and Open Source Software (FOSS) List
 
-* [Atom](#Atom)
-* [Filezilla](#Filezilla)
-* [Firefox](#Firefox)
-* [Gimp](#Gimp)
-* [Libreoffice](#LibreOffice)
-* [Pidgin](#Pidgin)
-* [Ricochet](#Ricochet)
-* [Thunderbird](#Thunderbird)
-* [VLC](#Vlc)
-* [Wordpress](#Wordpress)
+* Browser
+
+ > [Firefox](#Firefox)
+* Content Management System (CMS)
+  
+ > [Wordpress](#Wordpress)
+* Email
+
+ > [Thunderbird](#Thunderbird)
+* FTP Clients
+
+ > [Filezilla](#Filezilla)
+* Graphics
+
+ > [Gimp](#Gimp)
+* Messenger
+
+ > [Ricochet](#Ricochet), [Pidgin](#Pidgin)
+* Office Suite
+
+ > [Libreoffice](#LibreOffice)
+* Sound & Video
+
+ > [VLC](#Vlc)
+* Text Editor
+
+ > [Atom](#Atom)
 
 ---
 


### PR DESCRIPTION
Changed a couple things at the top. I thought it'd make more sense if the list header had a more specific name so people who don't know what FOSS is can easily understand. Also, I formatted the list to start naming the items from top to bottom in category instead of alphabetically by software name. I felt it was easier to navigate from top to bottom and to know from the get-go specifically what software is for what instead of having to needlessly scroll down to investigate. I added the software into a blockquote list series because once you add more software to the original list, in the long run it will just take up a lot more unnecessary space. Hope this helps to be a little more user friendly :).
